### PR TITLE
Add sort table feature

### DIFF
--- a/poe-profit-app/src/app/boss-details/boss-details.html
+++ b/poe-profit-app/src/app/boss-details/boss-details.html
@@ -130,10 +130,38 @@
                <table class="boss-table">
                   <thead>
                      <tr>
-                        <th class="header-item">Item</th>
-                        <th class="header-currency">Price</th>
-                        <th class="header-currency">Drop Rate</th>
-                        <th class="header-currency">Expected Value</th>
+                        <th class="header-item">
+                          <span class="sortable" (click)="sort('name')">
+                            Item
+                            <span class="sort-icon-wrapper" [ngClass]="getSortDirection('name')">
+                              <mat-icon class="sort-icon">unfold_more</mat-icon>
+                            </span>
+                          </span>
+                        </th>
+                        <th class="header-currency">
+                          <span class="sortable" (click)="sort('chaosValue')">
+                            Price
+                            <span class="sort-icon-wrapper" [ngClass]="getSortDirection('chaosValue')">
+                              <mat-icon class="sort-icon">unfold_more</mat-icon>
+                            </span>
+                          </span>
+                        </th>
+                        <th class="header-currency">
+                          <span class="sortable" (click)="sort('probability')">
+                            Drop Rate
+                            <span class="sort-icon-wrapper" [ngClass]="getSortDirection('probability')">
+                              <mat-icon class="sort-icon">unfold_more</mat-icon>
+                            </span>
+                          </span>
+                        </th>
+                        <th class="header-currency">
+                          <span class="sortable" (click)="sort('expectedValue')">
+                            Expected Value
+                            <span class="sort-icon-wrapper" [ngClass]="getSortDirection('expectedValue')">
+                              <mat-icon class="sort-icon">unfold_more</mat-icon>
+                            </span>
+                          </span>
+                        </th>
                      </tr>
                   </thead>
                   <tbody>

--- a/poe-profit-app/src/app/boss-details/boss-details.ts
+++ b/poe-profit-app/src/app/boss-details/boss-details.ts
@@ -41,6 +41,8 @@ interface BossDTO {
 })
 export class BossDetailComponent implements OnInit {
   boss?: BossDTO;
+  sortColumn: string = '';
+  sortDirection: 'asc' | 'desc' | 'unsorted' = 'unsorted';
 
   constructor(private route: ActivatedRoute, private http: HttpClient, private location: Location) {}
 
@@ -48,12 +50,37 @@ export class BossDetailComponent implements OnInit {
     const bossId = this.route.snapshot.paramMap.get('id');
     if (bossId) {
       this.http.get<BossDTO>(`http://localhost:8080/api/bosses/${bossId}`)
-        .subscribe(data => this.boss = data);
+        .subscribe(data => {
+          this.boss = data;
+          this.sort('expectedValue');
+        });
     }
   }
   
   // TODO: Move back to bosses pape
   goBack(): void {
     this.location.back();
+  }
+
+  sort(column: keyof Reward) {
+    if (this.sortColumn === column) {
+      this.sortDirection = this.sortDirection === 'asc' ? 'desc' : 'asc';
+    } else {
+      this.sortColumn = column;
+      this.sortDirection = 'desc';
+    }
+
+    this.boss?.rewards.sort((a, b) => {
+      const valueA = a[column];
+      const valueB = b[column];
+
+      if (valueA < valueB) return this.sortDirection === 'asc' ? -1 : 1;
+      if (valueA > valueB) return this.sortDirection === 'asc' ? 1 : -1;
+      return 0;
+    });
+  }
+
+  getSortDirection(column: string): 'asc' | 'desc' | 'unsorted' {
+    return this.sortColumn === column ? this.sortDirection : 'unsorted';
   }
 }

--- a/poe-profit-app/src/app/bosses/bosses.html
+++ b/poe-profit-app/src/app/bosses/bosses.html
@@ -23,10 +23,30 @@
                <table class="bosses-table">
                   <thead>
                      <tr>
-                        <th class="header-item">Name</th>
-                        <th class="header-currency">Cost</th>
-                        <th class="header-currency">Value</th>
-                        <th class="header-currency">Profit</th>
+                        <th class="header-item" (click)="sort('name')">
+                          Name 
+                          <span class="sort-icon-wrapper" [ngClass]="getSortDirection('name')">
+                            <mat-icon class="sort-icon">unfold_more</mat-icon>
+                          </span>
+                        </th>
+                        <th class="header-currency" (click)="sort('costInChaos')">
+                          Cost 
+                          <span class="sort-icon-wrapper" [ngClass]="getSortDirection('costInChaos')">
+                            <mat-icon class="sort-icon">unfold_more</mat-icon>
+                          </span>
+                        </th>
+                        <th class="header-currency" (click)="sort('expectedValueInChaos')">
+                          Value 
+                          <span class="sort-icon-wrapper" [ngClass]="getSortDirection('expectedValueInChaos')">
+                            <mat-icon class="sort-icon">unfold_more</mat-icon>
+                          </span>
+                        </th>
+                        <th class="header-currency" (click)="sort('profitInChaos')">
+                          Profit 
+                          <span class="sort-icon-wrapper" [ngClass]="getSortDirection('profitInChaos')">
+                            <mat-icon class="sort-icon">unfold_more</mat-icon>
+                          </span>
+                        </th>
                      </tr>
                   </thead>
                   <tbody>

--- a/poe-profit-app/src/app/bosses/bosses.html
+++ b/poe-profit-app/src/app/bosses/bosses.html
@@ -16,35 +16,43 @@
                <p class="bosses-description">
                   This table shows which boss gives you the <strong style="color: #efcd5c;">best profit per run</strong>.<br>
                   Profits are estimated using the expected reward value (<span style="color: #98fb98;">drop rate × item price</span>) minus the <span style="color: #ff5555;">cost of the fight</span>.<br>
-                  <strong style="color: #4fc3f7;">Click on each boss</strong> to get more information!
+                  <strong style="color: #4fc3f7;">Click on each boss</strong> to get more information.
                </p>
             </div>
             <div class="bosses-table-wrapper">
                <table class="bosses-table">
                   <thead>
                      <tr>
-                        <th class="header-item" (click)="sort('name')">
-                          Name 
-                          <span class="sort-icon-wrapper" [ngClass]="getSortDirection('name')">
-                            <mat-icon class="sort-icon">unfold_more</mat-icon>
+                        <th class="header-item">
+                          <span class="sortable" (click)="sort('name')">
+                            Name
+                            <span class="sort-icon-wrapper" [ngClass]="getSortDirection('name')">
+                              <mat-icon class="sort-icon">unfold_more</mat-icon>
+                            </span>
                           </span>
                         </th>
-                        <th class="header-currency" (click)="sort('costInChaos')">
-                          Cost 
-                          <span class="sort-icon-wrapper" [ngClass]="getSortDirection('costInChaos')">
-                            <mat-icon class="sort-icon">unfold_more</mat-icon>
+                        <th class="header-currency">
+                          <span class="sortable" (click)="sort('costInChaos')">
+                            Cost
+                            <span class="sort-icon-wrapper" [ngClass]="getSortDirection('costInChaos')">
+                              <mat-icon class="sort-icon">unfold_more</mat-icon>
+                            </span>
                           </span>
                         </th>
-                        <th class="header-currency" (click)="sort('expectedValueInChaos')">
-                          Value 
-                          <span class="sort-icon-wrapper" [ngClass]="getSortDirection('expectedValueInChaos')">
-                            <mat-icon class="sort-icon">unfold_more</mat-icon>
+                        <th class="header-currency">
+                          <span class="sortable" (click)="sort('expectedValueInChaos')">
+                            Value
+                            <span class="sort-icon-wrapper" [ngClass]="getSortDirection('expectedValueInChaos')">
+                              <mat-icon class="sort-icon">unfold_more</mat-icon>
+                            </span>
                           </span>
                         </th>
-                        <th class="header-currency" (click)="sort('profitInChaos')">
-                          Profit 
-                          <span class="sort-icon-wrapper" [ngClass]="getSortDirection('profitInChaos')">
-                            <mat-icon class="sort-icon">unfold_more</mat-icon>
+                        <th class="header-currency">
+                          <span class="sortable" (click)="sort('profitInChaos')">
+                            Profit
+                            <span class="sort-icon-wrapper" [ngClass]="getSortDirection('profitInChaos')">
+                              <mat-icon class="sort-icon">unfold_more</mat-icon>
+                            </span>
                           </span>
                         </th>
                      </tr>

--- a/poe-profit-app/src/app/bosses/bosses.ts
+++ b/poe-profit-app/src/app/bosses/bosses.ts
@@ -22,8 +22,8 @@ interface BossDTO {
 })
 export class BossesComponent implements OnInit {
   bosses: BossDTO[] = [];
-  sortColumn: string = 'profitInChaos';
-  sortDirection: 'asc' | 'desc' = 'asc';
+  sortColumn: string = '';
+  sortDirection: 'asc' | 'desc' | 'unsorted' = 'unsorted';
 
   constructor(private http: HttpClient, private router: Router) {}
 

--- a/poe-profit-app/src/app/bosses/bosses.ts
+++ b/poe-profit-app/src/app/bosses/bosses.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { HttpClient } from '@angular/common/http';
 import { RouterModule, Router } from '@angular/router';
+import { MatIconModule } from '@angular/material/icon';
 
 interface BossDTO {
   name: string;
@@ -15,21 +16,48 @@ interface BossDTO {
 @Component({
   selector: 'app-bosses',
   standalone: true,
-  imports: [CommonModule, RouterModule],
+  imports: [CommonModule, RouterModule, MatIconModule],
   templateUrl: './bosses.html',
   styleUrl: './bosses.css'
 })
 export class BossesComponent implements OnInit {
   bosses: BossDTO[] = [];
+  sortColumn: string = 'profitInChaos';
+  sortDirection: 'asc' | 'desc' = 'asc';
 
   constructor(private http: HttpClient, private router: Router) {}
 
   ngOnInit(): void {
     this.http.get<BossDTO[]>('http://localhost:8080/api/bosses')
-      .subscribe(data => this.bosses = data);
+      .subscribe(data => {
+        this.bosses = data;
+        this.sort('profitInChaos');
+      });
   }
 
   goToBoss(id: string) {
-  this.router.navigate(['/bosses', id]);
-}
+    this.router.navigate(['/bosses', id]);
+  }
+
+  sort(column: keyof BossDTO) {
+    if (this.sortColumn === column) {
+      this.sortDirection = this.sortDirection === 'asc' ? 'desc' : 'asc';
+    } else {
+      this.sortColumn = column;
+      this.sortDirection = 'desc';
+    }
+
+    this.bosses.sort((a, b) => {
+      const valueA = a[column];
+      const valueB = b[column];
+
+      if (valueA < valueB) return this.sortDirection === 'asc' ? -1 : 1;
+      if (valueA > valueB) return this.sortDirection === 'asc' ? 1 : -1;
+      return 0;
+    });
+  }
+
+  getSortDirection(column: string): 'asc' | 'desc' | 'unsorted' {
+    return this.sortColumn === column ? this.sortDirection : 'unsorted';
+  }
 }

--- a/poe-profit-app/src/styles.css
+++ b/poe-profit-app/src/styles.css
@@ -62,6 +62,11 @@ html, body {
   text-align: right;
 }
 
+.sortable {
+  user-select: none;
+  cursor: pointer;
+}
+
 .sort-icon {
   font-size: 1em;
   display: inline-block;

--- a/poe-profit-app/src/styles.css
+++ b/poe-profit-app/src/styles.css
@@ -62,6 +62,27 @@ html, body {
   text-align: right;
 }
 
+.sort-icon {
+  font-size: 1em;
+  display: inline-block;
+  vertical-align: middle;
+}
+
+.sort-icon-wrapper.asc .sort-icon {
+  clip-path: inset(0 0 50% 0);
+  transition: clip-path 0.5s ease;
+}
+
+.sort-icon-wrapper.desc .sort-icon {
+  clip-path: inset(50% 0 0 0);
+  transition: clip-path 0.5s ease;
+}
+
+.sort-icon-wrapper.unsorted .sort-icon {
+  clip-path: inset(0 0 0 0);
+  transition: clip-path 1s ease;
+}
+
 .cell-contents-currency {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Description
Add sort table feature to bosses and boss table.

## Changes
- Add sort icon to bosses and boss table
- Add sort feature to sort icon + table header
- Add default sort for bosses and boss table

<img width="1126" height="206" alt="Screenshot 2025-10-20 at 17-13-13 PoeProfitApp" src="https://github.com/user-attachments/assets/eca47f8f-7e17-4f5e-9f49-5d7a1bb3d2e1" />

<img width="1134" height="257" alt="Screenshot 2025-10-20 at 17-13-21 PoeProfitApp" src="https://github.com/user-attachments/assets/cb276cf3-331d-48d4-bb26-1ba2872ba885" />
