### PR TITLE
Color code profit

### DIFF
--- a/poe-profit-app/src/app/boss-details/boss-details.css
+++ b/poe-profit-app/src/app/boss-details/boss-details.css
@@ -121,6 +121,14 @@
   justify-content: center;
 }
 
+.profit-positive {
+  color: #4ade80 !important;
+}
+
+.profit-negative {
+  color: #f87171 !important;
+}
+
 .boss-top-content-right-container {
   flex: 2;
 }

--- a/poe-profit-app/src/app/boss-details/boss-details.html
+++ b/poe-profit-app/src/app/boss-details/boss-details.html
@@ -49,7 +49,12 @@
                   </div>
                   <div  class="boss-info-card">
                      <h4 class="boss-card-label">Profit</h4>
-                     <h3 class="boss-card-value">
+                     <h3 class="boss-card-value" 
+                           [ngClass]="{
+                                'profit-positive': boss.profitInChaos > 0,
+                                'profit-negative': boss.profitInChaos < 0
+                              }"
+                           >
                         {{ boss.profitInChaos | number : '1.0-0' }}
                         <img 
                            [src]="'chaos-orb.png'"

--- a/poe-profit-app/src/app/bosses/bosses.html
+++ b/poe-profit-app/src/app/bosses/bosses.html
@@ -92,10 +92,7 @@
                         </td>
                         <td>
                            <div class="cell-contents-currency"
-                                [ngClass]="{
-                                'profit-positive': boss.profitInChaos > 0,
-                                'profit-negative': boss.profitInChaos < 0
-                              }"
+                                [style.color]="getProfitColor(boss.profitInChaos)"
                            >
                               {{ boss.profitInChaos | number : '1.0-0' }}
                               <img 

--- a/poe-profit-app/src/app/bosses/bosses.html
+++ b/poe-profit-app/src/app/bosses/bosses.html
@@ -91,7 +91,12 @@
                            </div>
                         </td>
                         <td>
-                           <div class="cell-contents-currency">
+                           <div class="cell-contents-currency"
+                                [ngClass]="{
+                                'profit-positive': boss.profitInChaos > 0,
+                                'profit-negative': boss.profitInChaos < 0
+                              }"
+                           >
                               {{ boss.profitInChaos | number : '1.0-0' }}
                               <img 
                                  [src]="'chaos-orb.png'"

--- a/poe-profit-app/src/app/bosses/bosses.ts
+++ b/poe-profit-app/src/app/bosses/bosses.ts
@@ -60,4 +60,18 @@ export class BossesComponent implements OnInit {
   getSortDirection(column: string): 'asc' | 'desc' | 'unsorted' {
     return this.sortColumn === column ? this.sortDirection : 'unsorted';
   }
+
+  getProfitColor(value: number): string {
+    if (value > 0) {
+      const max = Math.max(...this.bosses.map(b => Math.abs(b.profitInChaos)));
+      const postiveNormalizationConst = Math.min(1, Math.abs(value) / max)
+      const positiveSat = 30 + postiveNormalizationConst * 70;
+      return `hsl(147, ${positiveSat}%, 50%)`;
+    } else {
+      const min = Math.min(...this.bosses.map(b => Math.abs(b.profitInChaos)));
+      const negativeNormalizationConst = Math.min(1, Math.abs(value) / min);
+      const negativeSat = 30 + negativeNormalizationConst * 70;
+      return `hsl(0, ${negativeSat}%, 50%)`;
+    }
+  }
 }

--- a/poe-profit-app/src/styles.css
+++ b/poe-profit-app/src/styles.css
@@ -103,3 +103,11 @@ display: flex;
   font-size: 0.9vw;
   gap: 0.5vw;
 }
+
+.profit-positive {
+  color: #4ade80 !important;
+}
+
+.profit-negative {
+  color: #f87171 !important;
+}

--- a/poe-profit-app/src/styles.css
+++ b/poe-profit-app/src/styles.css
@@ -103,11 +103,3 @@ display: flex;
   font-size: 0.9vw;
   gap: 0.5vw;
 }
-
-.profit-positive {
-  color: #4ade80 !important;
-}
-
-.profit-negative {
-  color: #f87171 !important;
-}


### PR DESCRIPTION
## Description
Color code profit value on bosses and boss page. Green for positive and red for negative

## Changes made
- Add color to profit on bosses page, intensity depends on max and min values
- Add color to profit on boss page

<img width="575" height="425" alt="Screenshot 2025-10-20 at 20-34-48 PoeProfitApp" src="https://github.com/user-attachments/assets/9b8cfc73-cc9d-482f-90fc-90f80e5c8a85" />
<img width="201" height="137" alt="Screenshot 2025-10-20 at 20-34-59 PoeProfitApp" src="https://github.com/user-attachments/assets/7b48859e-13a1-428c-bd04-8fd2b82f760e" />
